### PR TITLE
KETTLE-40: Wrapped CouchDB read/write in model transformation rules...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,7 +1089,7 @@ This can be applied to either a `kettle.dataSource.URL` or a `kettle.dataSource.
 This is a basic implementation which simply adapts the base documents in this API to a simple CRUD contract, taking care of:
 
 * Packaging and unpackaging the special `_id` and `_rev` fields which appear at top level in a CouchDB document
-    * The user's document is in fact escaped in a top-level path named `value` to avoid conflicts between its keys and any of those of the CouchDB machinery
+    * The user's document is in fact escaped in a top-level path named `value` to avoid conflicts between its keys and any of those of the CouchDB machinery.  If you wish to change this behavior, you can do so by providing different []model transformation rules](http://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html) in `options.rules.readPayload` and `options.rules.writePayload`.
 * Applying a "read-before-write" of the `_rev` field to minimise (but not eliminate completely) the possibility for a Couch-level conflict
 
 This grade is not properly tested and still carries some (though very small) risk of a conflict during update – it should be used with caution. Please contact the development team if

--- a/lib/dataSource.js
+++ b/lib/dataSource.js
@@ -464,9 +464,21 @@ kettle.dataSource.URL.handle.http = function (that, baseOptions, data) {
  * A mixin grade for a data source suitable for communicating with the /{db}/{docid} URL space of CouchDB for simple CRUD-style reading and writing
  */
 fluid.defaults("kettle.dataSource.CouchDB", {
+    mergePolicy: {
+        "rules": "nomerge"
+    },
+    rules: {
+        writePayload: {
+            value: ""
+        },
+        readPayload: {
+            "": "value"
+        }
+    },
     listeners: {
         onRead: {
             funcName: "kettle.dataSource.CouchDB.read",
+            args: ["{that}", "{arguments}.0"], // resp
             namespace: "CouchDB",
             priority: "after:encoding"
         }
@@ -488,12 +500,16 @@ fluid.makeGradeLinkage("kettle.dataSource.CouchDB.linkage", ["kettle.dataSource.
 
 
 /**
- * Convert a dataSource payload from CouchDB-encoded form - 
- * i) unpack our layer of "value" encoding for standard payloads
- * ii) decode a Couch error response into a promise failure
+ * Convert a dataSource payload from CouchDB-encoded form -
+ *
+ * i)  Decode a Couch error response into a promise failure
+ *
+ * ii) Transform the output from CouchDB using `that.options.rules.readPayload`.  The default rules reverse the default
+ *     "value" encoding used by `kettle.dataSource.CouchDB.write` (see below).
+ *
  * @param {resp} JSON-parsed response as received from CouchDB.
  */
-kettle.dataSource.CouchDB.read = function (resp) {
+kettle.dataSource.CouchDB.read = function (that, resp) {
     // if undefined, pass that through as per dataSource (just for consistency in FS-backed tests)
     var togo;
     if (resp === undefined) {
@@ -507,15 +523,23 @@ kettle.dataSource.CouchDB.read = function (resp) {
             togo = fluid.promise();
             togo.reject(error);
         } else {
-            togo = resp.value;
+            togo = fluid.model.transformWithRules(resp, that.options.rules.readPayload);
         }
     }
     return togo;
 };
 
+/**
+ * Convert `model` data for storage in CouchDB using the model transformation rules outlined in
+ * `that.options.rules.writePayload`.  By default, the entirety of the model is wrapped in a `value` element to avoid
+ * collisions with top-level CouchDB variables such as `_id` and `_rev`.
+ *
+ * @param {model} The data to be stored.
+ * @param {options} The `dataSource` options (see above).
+ */
 kettle.dataSource.CouchDB.write = function (that, model, options) {
     var directModel = options.directModel;
-    var doc = {value: model};
+    var doc = fluid.model.transformWithRules(model, that.options.rules.writePayload);
     var original = that.get(directModel, {filterNamespaces: ["encoding"]});
     var togo = fluid.promise();
     original.then(function (originalDoc) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "bugs": {
         "url": "http://issues.fluidproject.org/browse/KETTLE"
     },
+    "scripts": {
+        "test": "node tests/all-tests.js"
+    },
     "homepage": "http://wiki.fluidproject.org/display/fluid/Kettle",
     "dependencies": {
         "express": "~4.13.3",

--- a/tests/DataSourceTests.js
+++ b/tests/DataSourceTests.js
@@ -158,7 +158,7 @@ jqUnit.asyncTest("Writing file in formenc encoding", function () {
     var that = kettle.tests.formencSourceWrite();
     jqUnit.expect(1);
     that.set(null, kettle.tests.formencData).then(function () {
-        var written = fs.readFileSync("./data/writeable/formenc.txt", "utf8");
+        var written = fs.readFileSync(fluid.module.resolvePath("%kettle/tests/data/writeable/formenc.txt"), "utf8");
         var decoded = querystring.parse(written);
         jqUnit.assertDeepEq("Written decoded result", kettle.tests.formencData, decoded);
         jqUnit.start();


### PR DESCRIPTION
See [KETTLE-40](https://issues.fluidproject.org/browse/KETTLE-40) for details.
